### PR TITLE
Fix hardcoded organisation name in project tile

### DIFF
--- a/euth/projects/templates/euth_projects/includes/project_tile.html
+++ b/euth/projects/templates/euth_projects/includes/project_tile.html
@@ -7,8 +7,8 @@
         <h2 class="project-tile-title"><a href="{% url 'project-detail' project.slug %}">{{ project }}</a></h2>
         <p class="project-tile-teaser">{{ project.description|truncatechars:250 }}</p>
         <p class="project-tile-org">
-            <img src="" class="project-tile-org-avatar" alt=""/>
-            Liquid Democracy e.V.
+            <img src="{{ project.organisation.logo }}" class="project-tile-org-avatar" height="30" width="30" alt=""/>
+            {{ project.organisation.name }}
         </p>
     </div>
 </div>


### PR DESCRIPTION
This removes the hard coded "Liquid democracy e.V." from the bottom of the organisation tile. Currently those tiles are only used on organisation specific pages (e.g. organisations overview or section "other projects of this organisation" in project page). There for I am not sure how much sense this change makes.