### PR TITLE
2016 08 mn add avatar upload

### DIFF
--- a/euth/dashboard/apps.py
+++ b/euth/dashboard/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DashboardConfig(AppConfig):
+    name = 'euth.dashboard'
+    label = 'euth_dashboard'

--- a/euth/dashboard/templates/euth_dashboard/base_dashboard.html
+++ b/euth/dashboard/templates/euth_dashboard/base_dashboard.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% load i18n dashboard_templatetags %}
+
+
+{% block content %}
+<div class="container-narrow">
+    <div class="dashboard row">
+        <div class="col-md-3">
+            <div class="dashboard-nav">
+                <div class="list-group">
+                    {% url 'dashboard-overview' as dashboard_overview %}
+                    <a href="{{ dashboard_overview }}" class="list-group-item">
+                        <h4 class="list-group-item-heading {% selected request dashboard_overview %}">
+                            <i class="fa fa-home" aria-hidden="true"></i> {% trans 'Overview' %}
+                        </h4>
+                    </a>
+                    <!--<a href="#" class="list-group-item">
+                        <h4 class="list-group-item-heading">
+                            <i class="fa fa-rocket" aria-hidden="true"></i> Organisations
+                        </h4>
+                    </a>
+                    <a href="#" class="list-group-item">
+                        <h4 class="list-group-item-heading">
+                            <i class="fa fa-clone" aria-hidden="true"></i> Projects
+                        </h4>
+                    </a>
+                    <a href="#" class="list-group-item">
+                        <h4 class="list-group-item-heading">
+                            <i class="fa fa-check" aria-hidden="true"></i> Moderation
+                        </h4>
+                    </a>
+                    <a href="#" class="list-group-item">
+                        <h4 class="list-group-item-heading">
+                            <i class="fa fa-users" aria-hidden="true"></i> Users
+                        </h4>
+                    </a>-->
+                    {% url 'dashboard-profile' as dashboard_profile %}
+                    <a href="{{ dashboard_profile }}" class="list-group-item">
+                        <h4 class="list-group-item-heading {% selected request dashboard_profile %}">
+                            <i class="fa fa-user" aria-hidden="true"></i> {% trans 'Profile' %}
+                        </h4>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-9">
+            <div class="dashboard-content">
+                {% block dashboard_content %}
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+</div>
+
+
+{% endblock %}

--- a/euth/dashboard/templates/euth_dashboard/dashboard_overview.html
+++ b/euth/dashboard/templates/euth_dashboard/dashboard_overview.html
@@ -1,0 +1,6 @@
+{% extends "euth_dashboard/base_dashboard.html" %}
+{% load i18n %}
+
+{% block dashboard_content %}
+<h1>{% trans 'Overview' %}</h1>
+{% endblock %}

--- a/euth/dashboard/templates/euth_dashboard/profile_detail.html
+++ b/euth/dashboard/templates/euth_dashboard/profile_detail.html
@@ -1,6 +1,28 @@
 {% extends "euth_dashboard/base_dashboard.html" %}
-{% load i18n %}
+{% load widget_tweaks i18n %}
 
 {% block dashboard_content %}
 <h1>{% trans 'Profile' %}</h1>
+
+<div class="general-form">
+    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+            {% csrf_token %}
+            {{ form.media }}
+            {% for field in form %}
+            <div class="form-group {% if field.errors %}has-error {% endif %}">
+                <label>{{ field.label }}</label>
+                {% render_field field class="form-control" %}
+                {% if field.errors %}
+                <span class="help-block">{{ field.errors.0 }}</span>
+                {% endif %}
+            </div>
+            {% endfor %}
+            <button type="submit" class="submit-button">{% trans 'post'%}</button>
+            {% if mode == 'create' %}
+            <a href="{% url 'project-detail' project.slug %}" class="cancel-button">{% trans 'cancel'%}</a>
+            {% elif mode == 'update' %}
+            <a href="{% url 'idea-detail' idea.slug %}" class="cancel-button">{% trans 'cancel'%}</a>
+            {% endif %}
+    </form>
+</div>
 {% endblock %}

--- a/euth/dashboard/templates/euth_dashboard/profile_detail.html
+++ b/euth/dashboard/templates/euth_dashboard/profile_detail.html
@@ -1,0 +1,6 @@
+{% extends "euth_dashboard/base_dashboard.html" %}
+{% load i18n %}
+
+{% block dashboard_content %}
+<h1>{% trans 'Profile' %}</h1>
+{% endblock %}

--- a/euth/dashboard/templatetags/dashboard_templatetags.py
+++ b/euth/dashboard/templatetags/dashboard_templatetags.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def selected(request, pattern):
+    path = request.path
+    if path == pattern:
+        return 'selected'
+    return ''

--- a/euth/dashboard/urls.py
+++ b/euth/dashboard/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'profile/$',
+        views.DashboardProfileView.as_view(), name='dashboard-profile'),
+    url(r'',
+        views.DashboardOverviewView.as_view(), name='dashboard-overview'),
+]

--- a/euth/dashboard/views.py
+++ b/euth/dashboard/views.py
@@ -1,11 +1,23 @@
+from braces.views import LoginRequiredMixin
+from django.shortcuts import get_object_or_404
 from django.views import generic
 
+from euth.user_management import models as user_models
 
-class DashboardProfileView(generic.TemplateView):
 
+class DashboardProfileView(LoginRequiredMixin, generic.UpdateView):
+
+    model = user_models.User
     template_name = "euth_dashboard/profile_detail.html"
+    fields = ['avatar', 'email']
+
+    def get_object(self):
+        return get_object_or_404(user_models.User, pk=self.request.user.id)
+
+    def get_success_url(self):
+        return self.request.path
 
 
-class DashboardOverviewView(generic.TemplateView):
+class DashboardOverviewView(LoginRequiredMixin, generic.TemplateView):
 
     template_name = "euth_dashboard/dashboard_overview.html"

--- a/euth/dashboard/views.py
+++ b/euth/dashboard/views.py
@@ -1,0 +1,11 @@
+from django.views import generic
+
+
+class DashboardProfileView(generic.TemplateView):
+
+    template_name = "euth_dashboard/profile_detail.html"
+
+
+class DashboardOverviewView(generic.TemplateView):
+
+    template_name = "euth_dashboard/dashboard_overview.html"

--- a/euth/ideas/templates/euth_ideas/idea_detail.html
+++ b/euth/ideas/templates/euth_ideas/idea_detail.html
@@ -40,7 +40,11 @@
         </div>
 
         <div class="avatar-small">
+            {% if idea.creator.avatar %}
+            <img src="{{ idea.creator.avatar | thumbnail_url:'avatar_small' }}"></img>
+            {% else %}
             <img src=""></img>
+            {% endif %}
             <div class="name">{{ idea.creator.username }}</div>
         </div>
 
@@ -50,11 +54,6 @@
     </div>
 
     {% react_rates idea %}
-
-    <!--<div class="idea-rate">
-        <a class="idea-rate-btn idea-rate-up is-selected" href="#" title="{% trans 'Vote Up' %}"><i class="fa fa-chevron-up"></i> 33</a>
-        <a class="idea-rate-btn idea-rate-down" href="#" title="{% trans 'Vote Down' %}"><i class="fa fa-chevron-down"></i> 33</a>
-    </div>-->
 
 
         <div>

--- a/euth/ideas/templates/euth_ideas/includes/idea_list_tile.html
+++ b/euth/ideas/templates/euth_ideas/includes/idea_list_tile.html
@@ -17,15 +17,19 @@
                 </h3>
             </div>
             <div class="col-lg-4 pull-right idea-meta">
-                <!-- FIXME: votes -->
                 <span class="idea-upvotes idea-meta-item">{{ idea.positive_rates }} <i class="fa fa-chevron-up" aria-hidden="true"></i></span>
                 <span class="idea-downvotes idea-meta-item">{{ idea.negative_rates }} <i class="fa fa-chevron-down" aria-hidden="true"></i></span>
                 <span class="idea-comments-count idea-meta-item"><i class="fa fa-comment-o" aria-hidden="true"></i> {{ idea.comments.count }}</span>
             </div>
         </div>
         <div class="avatar-small">
-            <!-- FIXME: logo -->
-            <img src="/static/images/logo.svg" width="30" height="30" alt=""/><div class="name">{{ idea.creator.username }} <span class="idea-date"> {{ idea.created | date }}</span></div>
+            {% if idea.creator.avatar %}
+            <img src="{{ idea.creator.avatar | thumbnail_url:'avatar_small'}}" width="30" height="30" alt=""/>
+            {% else %}
+            <img src="/static/images/logo.svg" width="30" height="30" alt=""/>
+            {% endif %}
+            <div class="name">{{ idea.creator.username }} <span class="idea-date"> {{ idea.created | date }}</span>
+            </div>
         </div>
     </div>
 </div>

--- a/euth/user_management/apps.py
+++ b/euth/user_management/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
     label = 'user_management'
 
     def ready(self):
-        import euth.projects.signals  # noqa:F401
+        import euth.user_management.signals  # noqa:F401

--- a/euth/user_management/apps.py
+++ b/euth/user_management/apps.py
@@ -2,4 +2,8 @@ from django.apps import AppConfig
 
 
 class UsersConfig(AppConfig):
-    name = 'user_management'
+    name = 'euth.user_management'
+    label = 'user_management'
+
+    def ready(self):
+        import euth.projects.signals  # noqa:F401

--- a/euth/user_management/migrations/0003_user_avatar.py
+++ b/euth/user_management/migrations/0003_user_avatar.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import euth.contrib.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user_management', '0002_auto_20160715_1640'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='avatar',
+            field=models.ImageField(blank=True, upload_to='user_management/images', validators=[euth.contrib.validators.validate_logo]),
+        ),
+    ]

--- a/euth/user_management/models.py
+++ b/euth/user_management/models.py
@@ -4,13 +4,10 @@ from django.conf import settings
 from django.contrib.auth import models as auth_models
 from django.core import validators
 from django.db import models
-from django.db.models.signals import post_delete, post_init, post_save
-from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from euth.contrib import validators as euth_validators
-from euth.contrib import services
 
 USERNAME_INVALID_MESSAGE = _('Enter a valid username. This value may contain '
                              'only letters, digits, spaces and @/./+/-/_ '
@@ -83,20 +80,3 @@ class Reset(models.Model):
         on_delete=models.CASCADE
     )
     next_action = models.URLField(blank=True, null=True)
-
-
-@receiver(post_init, sender=User)
-def backup_image_path(sender, instance, **kwargs):
-    instance._current_image_file = instance.avatar
-
-
-@receiver(post_save, sender=User)
-def delete_old_image(sender, instance, **kwargs):
-    if hasattr(instance, '_current_image_file'):
-        if instance._current_image_file != instance.avatar:
-            services.delete_images([instance._current_image_file])
-
-
-@receiver(post_delete, sender=User)
-def delete_images_for_User(sender, instance, **kwargs):
-    services.delete_images([instance.avatar])

--- a/euth/user_management/models.py
+++ b/euth/user_management/models.py
@@ -43,6 +43,8 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
     is_active = models.BooleanField(_('active'), default=True,
                                     help_text=IS_ACTIVE_HELP)
     date_joined = models.DateTimeField(editable=False, default=timezone.now)
+    avatar = models.ImageField(upload_to='user_management/images', blank=True,
+                               validators=[euth_validators.validate_logo])
 
     objects = auth_models.UserManager()
 

--- a/euth/user_management/signals.py
+++ b/euth/user_management/signals.py
@@ -1,7 +1,8 @@
 from django.db.models import signals
 from django.dispatch import receiver
 
-from . import models, services
+from euth.contrib import services
+from . import models
 
 
 @receiver(signals.post_init, sender=models.User)

--- a/euth/user_management/signals.py
+++ b/euth/user_management/signals.py
@@ -1,0 +1,21 @@
+from django.db.models import signals
+from django.dispatch import receiver
+
+from . import models, services
+
+
+@receiver(signals.post_init, sender=models.User)
+def backup_image_path(sender, instance, **kwargs):
+    instance._current_image_file = instance.avatar
+
+
+@receiver(signals.post_save, sender=models.User)
+def delete_old_image(sender, instance, **kwargs):
+    if hasattr(instance, '_current_image_file'):
+        if instance._current_image_file != instance.avatar:
+            services.delete_images([instance._current_image_file])
+
+
+@receiver(signals.post_delete, sender=models.User)
+def delete_images_for_User(sender, instance, **kwargs):
+    services.delete_images([instance.avatar])

--- a/euth/user_management/templates/user_management/indicator_menu.html
+++ b/euth/user_management/templates/user_management/indicator_menu.html
@@ -10,6 +10,11 @@
                 <a href="{% url 'admin:index' %}">Admin</a>
             </li>
             {% endif %}
+            {% if user.is_authenticated %}
+            <li>
+                <a href="{% url 'dashboard-overview' %}">Dashboard</a>
+            </li>
+            {% endif %}
             <li>
                 <a href="">
                     <form class="logout-button-form" action="{% url 'logout' %}" method="post" >

--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
     'euth.modules.apps.ModuleConfig',
     'euth.ideas.apps.IdeaConfig',
     'euth.rates.apps.RatesConfig',
+    'euth.dashboard.apps.DashboardConfig'
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -63,7 +63,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'autofixture',
 
-    'euth.user_management',
+    'euth.user_management.apps.UsersConfig',
     'euth.organisations',
     'euth.projects',
     'euth.comments.apps.CommentConfig',

--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -64,8 +64,8 @@ INSTALLED_APPS = [
     'autofixture',
 
     'euth.user_management.apps.UsersConfig',
-    'euth.organisations',
-    'euth.projects',
+    'euth.organisations.apps.OrganisationsConfig',
+    'euth.projects.apps.ProjectsConfig',
     'euth.comments.apps.CommentConfig',
     'euth.phases.apps.PhasesConfig',
     'euth.modules.apps.ModuleConfig',

--- a/euth_wagtail/static/scss/all.scss
+++ b/euth_wagtail/static/scss/all.scss
@@ -31,3 +31,4 @@
 @import "scss/components/forms";
 @import "scss/components/avatars";
 @import "scss/components/ideas";
+@import "scss/components/dashboard";

--- a/euth_wagtail/static/scss/components/_dashboard.scss
+++ b/euth_wagtail/static/scss/components/_dashboard.scss
@@ -1,0 +1,40 @@
+.dashboard {
+    @include rem(padding, 113px 0px 0px 0px);
+}
+
+.dashboard-nav {
+
+    & a, a:active, a:focus, a:visited {
+        text-decoration: none;
+    }
+
+    & .list-group-item-heading {
+        background-color: $gray-lighter;
+        @include rem(padding, 20px 0px 20px 60px);
+        margin: 0px;
+        @include rem(font-size, 14px);
+        color: $black;
+
+        i {
+            color: $gray;
+        }
+    }
+
+    & .selected {
+        background-color: white;
+        color: $brand-brand1;
+        text-decoration: none;
+
+        i {
+            color: $brand-brand1;
+        }
+    }
+}
+
+.dashboard-content {
+    & h1 {
+        margin: 0px;
+        @include rem(font-size, 30px);
+    }
+}
+

--- a/euth_wagtail/urls.py
+++ b/euth_wagtail/urls.py
@@ -10,6 +10,7 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
 from euth.comments.api import CommentViewSet
+from euth.dashboard import urls as dashboard_urls
 from euth.ideas import urls as ideas_urls
 from euth.organisations import urls as organisations_urls
 from euth.projects import urls as projects_urls
@@ -34,6 +35,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     url(r'', include(user_urls)),
+    url(r'^dashboard/', include(dashboard_urls)),
     url(r'^orgs/', include(organisations_urls)),
     url(r'^projects/', include(projects_urls)),
     url(r'^ideas/', include(ideas_urls)),

--- a/tests/dashboard/test_dashboard_views.py
+++ b/tests/dashboard/test_dashboard_views.py
@@ -1,0 +1,43 @@
+import pytest
+from django.core.urlresolvers import reverse
+
+
+@pytest.mark.django_db
+def test_anonymous_cannot_view_dashboard_overview(client):
+    url = reverse('dashboard-overview')
+    response = client.get(url)
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_anonymous_cannot_view_dashboard_profile(client):
+    url = reverse('dashboard-profile')
+    response = client.get(url)
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_view_dashboard(client, user):
+    url = reverse('dashboard-overview')
+    login_url = reverse('login')
+    client.post(login_url, {'email': user.email, 'password': 'password'})
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_view_profile(client, user):
+    url = reverse('dashboard-profile')
+    login_url = reverse('login')
+    client.post(login_url, {'email': user.email, 'password': 'password'})
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_upload_avatar(client, user):
+    url = reverse('dashboard-profile')
+    login_url = reverse('login')
+    client.post(login_url, {'email': user.email, 'password': 'password'})
+    response = client.get(url)
+    assert response.status_code == 200

--- a/tests/rates/test_rate_models.py
+++ b/tests/rates/test_rate_models.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.db import IntegrityError
 
 

--- a/tests/user_management/test_models.py
+++ b/tests/user_management/test_models.py
@@ -6,7 +6,7 @@ from tests import helpers
 
 
 @pytest.mark.django_db
-def test_delete_idea(user_factory, ImagePNG):
+def test_delete_user_signal(user_factory, ImagePNG):
     user = user_factory(avatar=ImagePNG)
     image_path = os.path.join(settings.MEDIA_ROOT, user.avatar.path)
 

--- a/tests/user_management/test_models.py
+++ b/tests/user_management/test_models.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+from django.conf import settings
+from tests import helpers
+
+
+@pytest.mark.django_db
+def test_delete_idea(user_factory, ImagePNG):
+    user = user_factory(avatar=ImagePNG)
+    image_path = os.path.join(settings.MEDIA_ROOT, user.avatar.path)
+
+    assert os.path.isfile(image_path)
+
+    user.delete()
+    assert not os.path.isfile(image_path)
+
+
+@pytest.mark.django_db
+def test_image_deleted_after_update(user_factory, ImagePNG):
+    user = user_factory(avatar=ImagePNG)
+    image_path = os.path.join(settings.MEDIA_ROOT, user.avatar.path)
+    thumbnail_path = helpers.createThumbnail(user.avatar)
+
+    assert os.path.isfile(image_path)
+    assert os.path.isfile(thumbnail_path)
+
+    user.avatar = None
+    user.save()
+
+    assert not os.path.isfile(image_path)
+    assert not os.path.isfile(thumbnail_path)


### PR DESCRIPTION
This adds a first version of the dashboard, which also contains a profile tab (this might change as a separate profile page is planned). There users can change their avatar. 

@slomo: I added some signals to the user_management models.py. I would have put them in a separate signals.py but I somehow could not use AppConfig within the settings. Maybe you could take a look? 