### PR TITLE
2016 08 mn refactor rates

### DIFF
--- a/euth/comments/api.py
+++ b/euth/comments/api.py
@@ -19,7 +19,9 @@ class CommentViewSet(viewsets.ModelViewSet):
         """
         Sets the user of the request as user of the comment
         """
-        serializer = CommentSerializer(data=request.data)
+        serializer = CommentSerializer(
+            data=request.data,
+            context={'request': request})
 
         if serializer.is_valid():
             serializer.save(user=self.request.user)
@@ -36,7 +38,12 @@ class CommentViewSet(viewsets.ModelViewSet):
         """
         comment = self.get_object()
 
-        serializer = CommentSerializer(comment, {}, partial=True)
+        serializer = CommentSerializer(
+            comment,
+            {},
+            partial=True,
+            context={'request': request}
+        )
 
         if serializer.is_valid():
             obj = serializer.save()

--- a/euth/comments/migrations/0003_auto_20160823_0831.py
+++ b/euth/comments/migrations/0003_auto_20160823_0831.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('comments', '0002_auto_20160712_0744'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='comment',
+            options={'verbose_name': 'Comment', 'verbose_name_plural': 'Comments'},
+        ),
+    ]

--- a/euth/comments/serializers.py
+++ b/euth/comments/serializers.py
@@ -1,6 +1,8 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
+from euth.rates import models as rate_models
+
 from .models import Comment
 
 
@@ -8,10 +10,11 @@ class CommentSerializer(serializers.ModelSerializer):
     user_name = serializers.SerializerMethodField()
     child_comments = serializers.SerializerMethodField()
     is_deleted = serializers.SerializerMethodField()
+    rates = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
-        read_only_fields = ('modified', 'created', 'id', 'user_name')
+        read_only_fields = ('modified', 'created', 'id', 'user_name', 'rates')
         exclude = ('user', 'is_censored', 'is_removed')
 
     def get_user_name(self, obj):
@@ -31,7 +34,10 @@ class CommentSerializer(serializers.ModelSerializer):
         pk = obj.pk
         children = Comment.objects.all().filter(
             content_type=content_type, object_pk=pk).order_by('created')
-        serializer = CommentSerializer(children, many=True)
+        serializer = CommentSerializer(
+            children,
+            many=True,
+            context={'request': self.context['request']})
         return serializer.data
 
     def get_is_deleted(self, obj):
@@ -39,3 +45,31 @@ class CommentSerializer(serializers.ModelSerializer):
         Returns true is one of the flags is set
         """
         return (obj.is_censored or obj.is_removed)
+
+    def get_rates(self, obj):
+        """
+        Gets positve and negative rate count as well as
+        info on the request users rate
+        """
+        user = self.context['request'].user
+        contenttype = ContentType.objects.get_for_model(obj)
+        obj_rates = rate_models.Rate.objects.filter(
+            content_type=contenttype, object_pk=obj.pk)
+        positive_rates = obj_rates.filter(value=1).count()
+        negative_rates = obj_rates.filter(value=-1).count()
+        try:
+            user_rate = obj_rates.get(user=user)
+            user_rate_value = user_rate.value
+            user_rate_id = user_rate.pk
+        except:
+            user_rate_value = None
+            user_rate_id = None
+
+        result = {
+            'positive_rates': positive_rates,
+            'negative_rates': negative_rates,
+            'current_user_rate_value': user_rate_value,
+            'current_user_rate_id': user_rate_id
+        }
+
+        return result

--- a/euth/comments/static/comments/react_comments.js
+++ b/euth/comments/static/comments/react_comments.js
@@ -181,7 +181,11 @@ var CommentList = React.createClass({
           parentIndex: this.props.parentIndex,
           handleCommentDelete: this.props.handleCommentDelete,
           handleCommentSubmit: this.props.handleCommentSubmit,
-          handleCommentModify: this.props.handleCommentModify
+          handleCommentModify: this.props.handleCommentModify,
+          positiveRates: comment.rates.positive_rates,
+          negativeRates: comment.rates.negative_rates,
+          userRate: comment.rates.current_user_rate_value,
+          userRateId: comment.rates.current_user_rate_id
         },
           comment.comment
         )
@@ -297,7 +301,11 @@ var Comment = React.createClass({
             objectId: this.props.id,
             authenticatedAs: this.context.isAuthenticated ? this.context.user_name : null,
             pollInterval: 20000,
-            style: 'comments'
+            style: 'comments',
+            positiveRates: this.props.positiveRates,
+            negativeRates: this.props.negativeRates,
+            userRate: this.props.userRate,
+            userRateId: this.props.userRateId
           }
           ) : null,
 

--- a/euth/rates/api.py
+++ b/euth/rates/api.py
@@ -1,4 +1,4 @@
-from rest_framework import filters, mixins, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, viewsets
 from rest_framework.response import Response
 
 from .models import Rate
@@ -8,7 +8,6 @@ from .serializers import RateSerializer
 
 class RateViewSet(mixins.CreateModelMixin,
                   mixins.UpdateModelMixin,
-                  mixins.DestroyModelMixin,
                   viewsets.GenericViewSet):
 
     queryset = Rate.objects.all()
@@ -40,19 +39,8 @@ class RateViewSet(mixins.CreateModelMixin,
         NOTE: Rate is NOT deleted.
         """
         rate = self.get_object()
+        rate.value = 0
+        rate.save()
+        serializer = self.get_serializer(rate)
+        return Response(serializer.data)
 
-        serializer = RateSerializer(
-            rate,
-            {},
-            partial=True,
-            context={'request': request}
-        )
-
-        if serializer.is_valid():
-            obj = serializer.save()
-            obj.value = 0
-            obj.save()
-            return Response(serializer.data)
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)

--- a/euth/rates/api.py
+++ b/euth/rates/api.py
@@ -1,4 +1,4 @@
-from rest_framework import filters, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.response import Response
 
 from .models import Rate
@@ -6,7 +6,10 @@ from .permissions import IsUserOrReadOnly
 from .serializers import RateSerializer
 
 
-class RateViewSet(viewsets.ModelViewSet):
+class RateViewSet(mixins.CreateModelMixin,
+                  mixins.UpdateModelMixin,
+                  mixins.DestroyModelMixin,
+                  viewsets.GenericViewSet):
 
     queryset = Rate.objects.all()
     serializer_class = RateSerializer

--- a/euth/rates/api.py
+++ b/euth/rates/api.py
@@ -26,7 +26,6 @@ class RateViewSet(mixins.CreateModelMixin,
         NOTE: Rate is NOT deleted.
         """
         rate = self.get_object()
-        rate.value = 0
-        rate.save()
+        rate.update(0)
         serializer = self.get_serializer(rate)
         return Response(serializer.data)

--- a/euth/rates/api.py
+++ b/euth/rates/api.py
@@ -22,7 +22,10 @@ class RateViewSet(mixins.CreateModelMixin,
         """
         Sets the user of the request as user of the rate
         """
-        serializer = RateSerializer(data=request.data)
+        serializer = RateSerializer(
+            data=request.data,
+            context={'request': request}
+        )
 
         if serializer.is_valid():
             serializer.save(user=self.request.user)
@@ -38,7 +41,12 @@ class RateViewSet(mixins.CreateModelMixin,
         """
         rate = self.get_object()
 
-        serializer = RateSerializer(rate, {}, partial=True)
+        serializer = RateSerializer(
+            rate,
+            {},
+            partial=True,
+            context={'request': request}
+        )
 
         if serializer.is_valid():
             obj = serializer.save()

--- a/euth/rates/api.py
+++ b/euth/rates/api.py
@@ -1,4 +1,4 @@
-from rest_framework import filters, mixins, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, viewsets
 from rest_framework.response import Response
 
 from .models import Rate
@@ -15,23 +15,10 @@ class RateViewSet(mixins.CreateModelMixin,
     permission_classes = (
         permissions.IsAuthenticatedOrReadOnly, IsUserOrReadOnly)
     filter_backends = (filters.DjangoFilterBackend,)
-    filter_fields = ('object_pk', 'content_type', 'user', 'value')
+    filter_fields = ('object_pk', 'content_type')
 
-    def create(self, request):
-        """
-        Sets the user of the request as user of the rate
-        """
-        serializer = RateSerializer(
-            data=request.data,
-            context={'request': request}
-        )
-
-        if serializer.is_valid():
-            serializer.save(user=self.request.user)
-            return Response(serializer.data)
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
 
     def destroy(self, request, pk=None):
         """

--- a/euth/rates/models.py
+++ b/euth/rates/models.py
@@ -1,12 +1,16 @@
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from euth.contrib.base_models import TimeStampedModel
 
 
 class Rate(TimeStampedModel):
+
+    POSITIVE = 1
+    NEGATIVE = -1
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_pk = models.PositiveIntegerField()
@@ -27,9 +31,35 @@ class Rate(TimeStampedModel):
         return super().save(*args, **kwargs)
 
     def _get_value(self, number):
-        if number > 1:
-            return 1
-        elif number < -1:
-            return -1
+        if number > self.POSITIVE:
+            return self.POSITIVE
+        elif number < self.NEGATIVE:
+            return self.NEGATIVE
         else:
             return number
+
+    def get_meta_info(self, user):
+
+        rates = Rate.objects.filter(
+            content_type=self.content_type, object_pk=self.object_pk)
+        positive_rates_on_same_object = rates.filter(
+            value=self.POSITIVE).count()
+        negative_rates_on_same_object = rates.filter(
+            value=self.NEGATIVE).count()
+
+        try:
+            user_rate_on_same_object = rates.get(user=user)
+            user_rate_on_same_object_value = user_rate_on_same_object.value
+            user_rate_on_same_object_id = user_rate_on_same_object.pk
+        except ObjectDoesNotExist:
+            user_rate_on_same_object_value = None
+            user_rate_on_same_object_id = None
+
+        result = {
+            'positive_rates_on_same_object': positive_rates_on_same_object,
+            'negative_rates_on_same_object': negative_rates_on_same_object,
+            'user_rate_on_same_object_value': user_rate_on_same_object_value,
+            'user_rate_on_same_object_id': user_rate_on_same_object_id
+        }
+
+        return result

--- a/euth/rates/models.py
+++ b/euth/rates/models.py
@@ -63,3 +63,7 @@ class Rate(TimeStampedModel):
         }
 
         return result
+
+    def update(self, value):
+        self.value = 0
+        self.save()

--- a/euth/rates/serializers.py
+++ b/euth/rates/serializers.py
@@ -1,15 +1,42 @@
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
+
+from euth.rates import models as rate_models
 
 from .models import Rate
 
 
 class RateSerializer(serializers.ModelSerializer):
-    user_name = serializers.SerializerMethodField()
+    meta_info = serializers.SerializerMethodField()
 
     class Meta:
         model = Rate
-        read_only_fields = ('id', 'user_name')
+        read_only_fields = ('id', 'meta_info')
         exclude = ('user', 'modified', 'created')
 
-    def get_user_name(self, obj):
-        return str(obj.user.username)
+    def get_meta_info(self, obj):
+        user = self.context['request'].user
+        related_obj = obj.content_object
+        contenttype = ContentType.objects.get_for_model(related_obj)
+        pk = related_obj.id
+        rates = rate_models.Rate.objects.all().filter(
+            content_type=contenttype, object_pk=pk)
+        positive_rates_on_same_object = rates.filter(value=1).count()
+        negative_rates_on_same_object = rates.filter(value=-1).count()
+
+        try:
+            user_rate_on_same_object = rates.get(user=user)
+            user_rate_on_same_object_value = user_rate_on_same_object.value
+            user_rate_on_same_object_id = user_rate_on_same_object.pk
+        except:
+            user_rate_on_same_object_value = None
+            user_rate_on_same_object_id = None
+
+        result = {
+            'positive_rates_on_same_object': positive_rates_on_same_object,
+            'negative_rates_on_same_object': negative_rates_on_same_object,
+            'user_rate_on_same_object_value': user_rate_on_same_object_value,
+            'user_rate_on_same_object_id': user_rate_on_same_object_id
+        }
+
+        return result

--- a/euth/rates/serializers.py
+++ b/euth/rates/serializers.py
@@ -1,7 +1,4 @@
-from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
-
-from euth.rates import models as rate_models
 
 from .models import Rate
 
@@ -16,27 +13,4 @@ class RateSerializer(serializers.ModelSerializer):
 
     def get_meta_info(self, obj):
         user = self.context['request'].user
-        related_obj = obj.content_object
-        contenttype = ContentType.objects.get_for_model(related_obj)
-        pk = related_obj.id
-        rates = rate_models.Rate.objects.all().filter(
-            content_type=contenttype, object_pk=pk)
-        positive_rates_on_same_object = rates.filter(value=1).count()
-        negative_rates_on_same_object = rates.filter(value=-1).count()
-
-        try:
-            user_rate_on_same_object = rates.get(user=user)
-            user_rate_on_same_object_value = user_rate_on_same_object.value
-            user_rate_on_same_object_id = user_rate_on_same_object.pk
-        except:
-            user_rate_on_same_object_value = None
-            user_rate_on_same_object_id = None
-
-        result = {
-            'positive_rates_on_same_object': positive_rates_on_same_object,
-            'negative_rates_on_same_object': negative_rates_on_same_object,
-            'user_rate_on_same_object_value': user_rate_on_same_object_value,
-            'user_rate_on_same_object_id': user_rate_on_same_object_id
-        }
-
-        return result
+        return obj.get_meta_info(user)

--- a/euth/rates/static/rates/react_rates.js
+++ b/euth/rates/static/rates/react_rates.js
@@ -11,24 +11,6 @@ $(function () {
 })
 
 var RateBox = React.createClass({
-
-  loadRatesFromServer: function () {
-    $.ajax({
-      url: this.props.url,
-      dataType: 'json',
-      cache: false,
-      data: {
-        object_pk: this.props.objectId,
-        content_type: this.props.contentType
-      },
-      success: function (rates) {
-        this.updateRateList(rates)
-      }.bind(this),
-      error: function (xhr, status, err) {
-        console.error(this.props.url, status, err.toString())
-      }.bind(this)
-    })
-  },
   handleRateCreate: function (number) {
     $.ajax({
       url: this.props.url,
@@ -40,8 +22,13 @@ var RateBox = React.createClass({
         value: number
       },
       success: function (data) {
-        this.state.rates.push(data)
-        this.updateRateList(this.state.rates)
+        this.setState({
+          positiveRates: data.meta_info.positive_rates_on_same_object,
+          negativeRates: data.meta_info.negative_rates_on_same_object,
+          userRate: data.meta_info.user_rate_on_same_object_value,
+          userHasRated: true,
+          userRateId: data.id
+        })
       }.bind(this),
       error: function (xhr, status, err) {
         console.error(status, err.toString())
@@ -55,44 +42,15 @@ var RateBox = React.createClass({
       type: 'PATCH',
       data: { value: number },
       success: function (data) {
-        this.updateUserRate(data)
-        this.updateRateList(this.state.rates)
+        this.setState({
+          positiveRates: data.meta_info.positive_rates_on_same_object,
+          negativeRates: data.meta_info.negative_rates_on_same_object,
+          userRate: data.meta_info.user_rate_on_same_object_value
+        })
       }.bind(this),
       error: function (xhr, status, err) {
         console.error(status, err.toString())
       }
-    })
-  },
-  updateRateList: function (rates) {
-    var positiveRates = 0
-    var negativeRates = 0
-    var userHasRated = false
-    var userRate = 0
-    var userRateId = -1
-    var userRateIndex = -1
-    var username = this.props.authenticatedAs
-    $.each(rates, function (index, value) {
-      if (value.user_name === username) {
-        userHasRated = true
-        userRate = value.value
-        userRateId = value.id
-        userRateIndex = index
-      }
-      if (value.value === 1) {
-        positiveRates++
-      }
-      if (value.value === -1) {
-        negativeRates++
-      }
-    })
-    this.setState({
-      positiveRates: positiveRates,
-      negativeRates: negativeRates,
-      rates: rates,
-      userHasRated: userHasRated,
-      userRate: userRate,
-      userRateId: userRateId,
-      userRateIndex: userRateIndex
     })
   },
   updateUserRate: function (data) {
@@ -136,15 +94,15 @@ var RateBox = React.createClass({
   },
   getInitialState: function () {
     return {
-      positiveRates: 0,
-      negativeRates: 0,
-      userHasRated: false,
-      userRate: 0
+      positiveRates: this.props.positiveRates,
+      negativeRates: this.props.negativeRates,
+      userHasRated: this.props.userRate,
+      userRate: this.props.userRate,
+      userRateId: this.props.userRateId
     }
   },
   componentDidMount: function () {
-    this.loadRatesFromServer()
-    setInterval(this.loadRatesFromServer, this.props.pollInterval)
+    this.getInitialState()
   },
   render: function () {
     if (this.props.style === 'comments') {
@@ -199,10 +157,14 @@ var RateBox = React.createClass({
 
 module.exports.RateBox = RateBox
 
-module.exports.renderRates = function (url, loginUrl, contentType, objectId, authenticatedAs, style, target) {
+module.exports.renderRates = function (url, positiveRates, negativeRates, userRate, userRateId, loginUrl, contentType, objectId, authenticatedAs, style, target) {
   ReactDOM.render(
     h(RateBox, {
       url: url,
+      positiveRates: positiveRates,
+      negativeRates: negativeRates,
+      userRate: (userRate === 'None') ? null : parseInt(userRate),
+      userRateId: (userRateId === 'None') ? null : parseInt(userRateId),
       loginUrl: loginUrl,
       contentType: contentType,
       objectId: objectId,

--- a/euth/rates/static/rates/react_rates.js
+++ b/euth/rates/static/rates/react_rates.js
@@ -96,7 +96,7 @@ var RateBox = React.createClass({
     return {
       positiveRates: this.props.positiveRates,
       negativeRates: this.props.negativeRates,
-      userHasRated: this.props.userRate,
+      userHasRated: this.props.userRate !== null,
       userRate: this.props.userRate,
       userRateId: this.props.userRateId
     }

--- a/euth/rates/templates/rates/react_rates.html
+++ b/euth/rates/templates/rates/react_rates.html
@@ -1,4 +1,4 @@
 <div id="rates_for_{{contenttype}}_{{pk}}"></div>
 <script>
-  window.Opin.renderRates("{% url 'rates-list'%}", "{{ login_url }}", {{contenttype}}, {{object_id}}, {% if authenticated_as %}"{{ authenticated_as|escapejs }}"{% else %}null{% endif %}, "ideas", "rates_for_{{contenttype}}_{{pk}}")
+  window.Opin.renderRates("{% url 'rates-list'%}", {{positive_rates}}, {{negative_rates}}, "{{ user_rate }}", "{{ user_rate_id }}", "{{ login_url }}", {{contenttype}}, {{object_id}}, {% if authenticated_as %}"{{ authenticated_as|escapejs }}"{% else %}null{% endif %}, "ideas", "rates_for_{{contenttype}}_{{pk}}")
 </script>

--- a/euth/rates/templatetags/react_rates.py
+++ b/euth/rates/templatetags/react_rates.py
@@ -2,6 +2,8 @@ from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 
+from euth.rates import models as rate_models
+
 register = template.Library()
 
 
@@ -11,18 +13,32 @@ def react_rates(context, obj):
     login_url = reverse('login') + '?next=' + context['request'].path
 
     contenttype = ContentType.objects.get_for_model(obj)
-    pk = obj.pk
 
-    if context['request'].user.is_authenticated():
-        authenticated_as = context['request'].user.username
+    user = context['request'].user
+
+    if user.is_authenticated():
+        authenticated_as = user.username
     else:
         authenticated_as = None
+
+    try:
+        user_rate = rate_models.Rate.objects.get(
+            content_type=contenttype, object_pk=obj.pk, user=user)
+        user_rate_value = user_rate.value
+        user_rate_id = user_rate.pk
+    except:
+        user_rate_value = None
+        user_rate_id = -1
 
     context = {
         'login_url': login_url,
         'contenttype': contenttype.pk,
-        'object_id': pk,
+        'object_id': obj.pk,
         'authenticated_as': authenticated_as,
+        'positive_rates': obj.positive_rates,
+        'negative_rates': obj.negative_rates,
+        'user_rate': user_rate_value,
+        'user_rate_id': user_rate_id,
     }
 
     return context

--- a/tests/comments/conftest.py
+++ b/tests/comments/conftest.py
@@ -1,5 +1,7 @@
 from pytest_factoryboy import register
+from tests.rates import factories as rate_factories
 
-import factories
+import factories as comment_factories
 
-register(factories.CommentFactory)
+register(rate_factories.RateFactory)
+register(comment_factories.CommentFactory)

--- a/tests/rates/conftest.py
+++ b/tests/rates/conftest.py
@@ -1,4 +1,6 @@
 from pytest_factoryboy import register
-from tests.rates import factories
+from tests.comments import factories as comment_factories
+from tests.rates import factories as rates_factories
 
-register(factories.RateFactory)
+register(rates_factories.RateFactory)
+register(comment_factories.CommentFactory)

--- a/tests/rates/test_rate_api.py
+++ b/tests/rates/test_rate_api.py
@@ -46,7 +46,7 @@ def test_authenticated_user_can_post_valid_data(user, apiclient):
         'content_type': 1
     }
     response = apiclient.post(url, data, format='json')
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_201_CREATED
 
 
 @pytest.mark.django_db
@@ -131,7 +131,7 @@ def test_meta_info_of_rate(rate_factory, comment,  apiclient, user, user2):
     }
     response = apiclient.post(url, data, format='json')
     rate_id = response.data['id']
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data['value'] == 1
     assert response.data['meta_info']['positive_rates_on_same_object'] == 1
     assert response.data['meta_info']['user_rate_on_same_object_value'] == 1
@@ -139,7 +139,7 @@ def test_meta_info_of_rate(rate_factory, comment,  apiclient, user, user2):
     apiclient.force_authenticate(user2)
     response = apiclient.post(url, data, format='json')
     rate_id = response.data['id']
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data['value'] == 1
     assert response.data['meta_info']['positive_rates_on_same_object'] == 2
     assert response.data['meta_info']['user_rate_on_same_object_value'] == 1

--- a/tests/rates/test_rate_models.py
+++ b/tests/rates/test_rate_models.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.db import IntegrityError
 
 


### PR DESCRIPTION
fixes #185 
fixes #178 

PRO
* rate-list and rate-detail api do not accept GET Requests anymore
* creator of rate is not exposed via the rate api
* still uses just one react component
* no extra requests to get the rates
* comment-API ans Rate-API now expose information on rates-count
* comment (for a authenticated user, who hast rated) looks like this:
```
{ 
    "id": 38,         
     "user_name": "admin",        
     "child_comments": [],
        "is_deleted": false,
        "rates": {
            "current_user_rate_id": 65,
            "positive_rates": 0,
            "negative_rates": 0,
            "current_user_rate_value": 0
        },
        "created": "2016-08-18T08:39:46.342312Z",
        "modified": null,
        "object_pk": 6,
        "comment": "My comment",
        "content_type": 50
}
```
  * rate detail (for a authenticated user, who hast rated) looks like this
```
{
    "id": 66,
    "meta_info": {
        "user_rate_on_same_object_value": 1,
        "negative_rates_on_same_object": 0,
        "user_rate_on_same_object_id": 66,
        "positive_rates_on_same_object": 1
    },
    "object_pk": 7,
    "value": 1,
    "content_type": 50
}
```
CONTRA:
* API might be confusing
* API not really RESTful