### PR TITLE
Move upload-wrapper class into widget definition

### DIFF
--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -7,11 +7,15 @@ from django.utils.translation import ugettext
 
 
 class ImageInputWidget(widgets.ClearableFileInput):
-    def render(self, name, value, attrs=None):
-        file_input = super(widgets.ClearableFileInput, self)\
-            .render(name, value, attrs)
+    """
+    A project-sepcific improved version of the clearable file upload.
 
+    Allows to upload and delete uploaded files. It doesn't passing attributes
+    using the positional `attrs` argument and hard codes css files.
+    """
+    def render(self, name, value, attrs=None):
         substitutions = {
+            'name': name,
             'filename': '',
             'file_placeholder': ugettext(
                 'Select a picture from your local folder.'
@@ -23,10 +27,17 @@ class ImageInputWidget(widgets.ClearableFileInput):
             'clear_title': ugettext('Remove the picture'),
         }
         snippets = {
+            'file_input': (
+                super(widgets.ClearableFileInput, self).render(name, value, {
+                    'id': name,
+                    'class': 'form-control form-control-file'
+                })
+            ),
             'text_input': (
-                '<input type="text"'
-                'class="form-control form-control-file-dummy"'
-                'value="{filename}" placeholder="{file_placeholder}">'
+                widgets.TextInput().render('__noname__', '{filename}', {
+                    'class': 'form-control',
+                    'placeholder': '{file_placeholder}'
+                })
             ),
             'alert': (
                 '<div class="alert alert-info" role="alert">{post_note}</div>'
@@ -54,21 +65,22 @@ class ImageInputWidget(widgets.ClearableFileInput):
                                    'class': 'clear-image'})
         else:
             snippets['button'] = (
-                '<label for="id_image" class="btn btn-default"'
+                '<label for="{name}" class="btn btn-default"'
                 'title="{upload_title}">'
                 '<i class="fa fa-cloud-upload"></i></label>'
             )
 
         markup = """
-        <div class="upload-wrapper">
+        <div class="upload-wrapper form-control-upload">
             {text_input}
             <span class="input-group-btn">
                 {button}
             </span>
+            {file_input}
             {alert}
+            {checkbox}
+            {img}
         </div>
-        {checkbox}
-        {img}
         """.format(**snippets).format(**substitutions)
 
-        return mark_safe(markup + file_input)
+        return mark_safe(markup)

--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext
 
 class ImageInputWidget(widgets.ClearableFileInput):
     """
-    A project-sepcific improved version of the clearable file upload.
+    A project-specific improved version of the clearable file upload.
 
     Allows to upload and delete uploaded files. It doesn't passing attributes
     using the positional `attrs` argument and hard codes css files.
@@ -35,7 +35,7 @@ class ImageInputWidget(widgets.ClearableFileInput):
             ),
             'text_input': (
                 widgets.TextInput().render('__noname__', '{filename}', {
-                    'class': 'form-control',
+                    'class': 'form-control form-control-file-dummy',
                     'placeholder': '{file_placeholder}'
                 })
             ),
@@ -71,15 +71,17 @@ class ImageInputWidget(widgets.ClearableFileInput):
             )
 
         markup = """
-        <div class="upload-wrapper form-control-upload">
-            {text_input}
-            <span class="input-group-btn">
-                {button}
-            </span>
-            {file_input}
-            {alert}
-            {checkbox}
-            {img}
+        <div class="row">
+            <div class="upload-wrapper form-control-upload col-sm-9 col-md-8">
+                {text_input}
+                <span class="input-group-btn">
+                    {button}
+                </span>
+                {file_input}
+                {alert}
+                {checkbox}
+                {img}
+            </div>
         </div>
         """.format(**snippets).format(**substitutions)
 

--- a/euth/dashboard/templates/euth_dashboard/profile_detail.html
+++ b/euth/dashboard/templates/euth_dashboard/profile_detail.html
@@ -8,12 +8,10 @@
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
             {% csrf_token %}
             {{ form.media }}
-            <div class="col-sm-8 col-md-9">
-                <div class="form-group {% if form.avatar.errors %}has-error {% endif %}">
-                    <label>{{ form.avatar.label }}</label>
-                    {{ form.avatar }}
-                    {{ form.avatar.errors }}
-                </div>
+            <div class="form-group {% if form.avatar.errors %}has-error {% endif %}">
+                <label>{{ form.avatar.label }}</label>
+                {{ form.avatar }}
+                {{ form.avatar.errors }}
             </div>
             <div class="form-group {% if form.email.errors %}has-error {% endif %}">
                 <label>{{ form.email.label }}</label>

--- a/euth/dashboard/templates/euth_dashboard/profile_detail.html
+++ b/euth/dashboard/templates/euth_dashboard/profile_detail.html
@@ -8,13 +8,11 @@
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
             {% csrf_token %}
             {{ form.media }}
-            <div class="form-group {% if form.avatar.errors %}has-error {% endif %}">
-                <div class="input-group form-control-upload row">
-                    <div class="col-sm-8 col-md-9">
-                        <label>{{ form.avatar.label }}</label>
-                        {{ form.avatar|add_class:"form-control form-control-file"}}
-                        {{ form.avatar.errors }}
-                    </div>
+            <div class="col-sm-8 col-md-9">
+                <div class="form-group {% if form.avatar.errors %}has-error {% endif %}">
+                    <label>{{ form.avatar.label }}</label>
+                    {{ form.avatar }}
+                    {{ form.avatar.errors }}
                 </div>
             </div>
             <div class="form-group {% if form.email.errors %}has-error {% endif %}">

--- a/euth_wagtail/static/js/euth_wagtail.js
+++ b/euth_wagtail/static/js/euth_wagtail.js
@@ -41,4 +41,9 @@ $(document).ready(function () {
             }
         }
     });
+
+  $(".form-control-file").change(function() {
+    var string = $(this).val().match(/[^\\/]+$/)[0]
+    $(this).parent().find(".form-control-file-dummy").val(string)
+  });
 });

--- a/euth_wagtail/static/scss/components/_forms.scss
+++ b/euth_wagtail/static/scss/components/_forms.scss
@@ -72,8 +72,11 @@
                     position: absolute;
                     z-index: 10;
                     top: 0;
-                    right: 0;
+                    right: 0px;
                     width: auto;
+                }
+                &.col-sm-9 .input-group-btn {
+                    right: 15px;
                 }
             }
         }


### PR DESCRIPTION
Issues fixed:

- [x] `upload-wrapper` class needs to surround the form field
- [x] wrapping field in `col` class will result in buttons and labels floating arround
- [ ] ~~deleting and uploading new image doesn't work (probably anoying to fix)~~ (see #261)