### PR TITLE
Mn 2016 10 fix logo stylings

### DIFF
--- a/euth/organisations/templates/euth_organisations/organisation_detail.html
+++ b/euth/organisations/templates/euth_organisations/organisation_detail.html
@@ -26,7 +26,7 @@
                     {% if organisation.logo %}
                     <img alt="{{ organisation.name }} logo" src="{{ organisation.logo|thumbnail_url:'organisation_thumbnail' }}">
                     {% else %}
-                    <img alt="opin logo" src="{% static "images/logo.svg" %}">
+                    <img alt="opin logo" src="{% static "images/logo.png" %}">
                     {% endif %}
                 </div>
                 <h1 class="euth-hero-unit-title">{{ organisation.name }}</h1>
@@ -37,7 +37,7 @@
     </div>
 </header>
 <div class="accordion-block">
-    <div class="container">
+    <div class="container">l
         <div class="container-narrow">
             <h2 class="accordion-title" id="organisation-title">
                 <a class="accordion-link collapsed" role="button" data-toggle="collapse" href="#organisation-panel" aria-expanded="false" aria-controls="organisation-panel">

--- a/euth/organisations/templates/euth_organisations/organisation_detail.html
+++ b/euth/organisations/templates/euth_organisations/organisation_detail.html
@@ -26,7 +26,7 @@
                     {% if organisation.logo %}
                     <img alt="{{ organisation.name }} logo" src="{{ organisation.logo|thumbnail_url:'organisation_thumbnail' }}">
                     {% else %}
-                    <img alt="opin logo" src="{% static "images/logo.png" %}">
+                    <img alt="opin logo" src="{% static "images/logo.svg" %}">
                     {% endif %}
                 </div>
                 <h1 class="euth-hero-unit-title">{{ organisation.name }}</h1>

--- a/euth_wagtail/static/scss/components/_hero-unit.scss
+++ b/euth_wagtail/static/scss/components/_hero-unit.scss
@@ -50,7 +50,7 @@
 }
 
 .org-header .euth-hero-unit-logo img {
-    max-width: 70%;
+    max-width: 60%;
 }
 
 .euth-hero-unit-image {


### PR DESCRIPTION
fixes #336 

@vellip I guess the change in _hero-unit.css has been made for a reason. If we put max-width to 60% the whole definition in _hero-unit.css can be deleted 