### PR TITLE
Organisation's "Go to project"-button and more

### DIFF
--- a/euth/organisations/templates/euth_organisations/organisation_detail.html
+++ b/euth/organisations/templates/euth_organisations/organisation_detail.html
@@ -31,7 +31,6 @@
                 </div>
                 <h1 class="euth-hero-unit-title">{{ organisation.name }}</h1>
                 <p class="org-location"><i class="fa fa-map-marker"></i>  {{organisation.place}}, {{organisation.country.name}}</p>
-                <a href="#project-tile-grid" class="button button-white">Go to projects</a>
             </div>
         </div>
     </div>

--- a/euth_wagtail/static/scss/components/_accordion-block.scss
+++ b/euth_wagtail/static/scss/components/_accordion-block.scss
@@ -15,13 +15,13 @@
 
     .accordion-title {
         margin: 0;
-        @include rem(padding, 30px 0);
+        @include rem(padding, 5px 0);
         text-align: center;
 
         .accordion-link {
             @include rem(font-size, $font-size-medium);
             @include rem(padding, 20px 0);
-            color: $black;
+            color: $gray-darker;
             display: block;
             font-family: $font-family-sans-serif;
             line-height: 1.2;
@@ -30,8 +30,7 @@
             &:after {
                 content: "–";
                 @include rem(font-size, $font-size-large);
-                vertical-align: middle;
-                @include rem(margin-left, 25px);
+                @include rem(margin-left, 20px);
             }
 
             &.collapsed {
@@ -47,7 +46,7 @@
     }
 
     .panel-body {
-        @include rem(padding-bottom, 105px);
+        @include rem(padding-bottom, 50px);
         @include rem(font-size, $font-size-base);
         line-height: 1.75;
     }

--- a/euth_wagtail/static/scss/components/_orgs.scss
+++ b/euth_wagtail/static/scss/components/_orgs.scss
@@ -110,6 +110,7 @@
 .org-location {
     @include  rem(font-size, $font-size-medium);
     @include rem(font-size, 20px);
+    margin: 0;
 }
 
 .org-location .fa {
@@ -130,7 +131,7 @@
         color: #fff;
 
         &:hover {
-            color: #fff;
+            color: $gray-light;
             text-decoration: underline;
         }
     }

--- a/euth_wagtail/static/scss/components/_orgs.scss
+++ b/euth_wagtail/static/scss/components/_orgs.scss
@@ -132,7 +132,6 @@
 
         &:hover {
             color: $gray-light;
-            text-decoration: underline;
         }
     }
 }


### PR DESCRIPTION
Issue:
Organisation Page: kill button "Go To Projects" #415
- deleted the "go to project" button
- adjusted the height of the header image 
- adjusted the accordion 
- social media icons now get a little darker on hover
