### PR TITLE
Improve input focus

### DIFF
--- a/euth/dashboard/templates/euth_dashboard/includes/project_form_result_tab.html
+++ b/euth/dashboard/templates/euth_dashboard/includes/project_form_result_tab.html
@@ -7,7 +7,7 @@
         <div class="form-section-fields">
 
             <div class="form-group{% if field.errors %} has-error{% endif %}" style="margin-top: -30px;">
-                <label for="form.project.result.id_for_label">{{ form.result.label }}</label>
+                <label for="{{form.project.result.id_for_label}}">{{ form.result.label }}</label>
                 {% render_field form.project.result class="form-control" %}
                 <span class="help-block">{{ error }}</span>
             </div>

--- a/euth/dashboard/templates/euth_dashboard/includes/project_form_result_tab.html
+++ b/euth/dashboard/templates/euth_dashboard/includes/project_form_result_tab.html
@@ -7,7 +7,7 @@
         <div class="form-section-fields">
 
             <div class="form-group{% if field.errors %} has-error{% endif %}" style="margin-top: -30px;">
-                <label>{{ form.result.label }}</label>
+                <label for="form.project.result.id_for_label">{{ form.result.label }}</label>
                 {% render_field form.project.result class="form-control" %}
                 <span class="help-block">{{ error }}</span>
             </div>

--- a/euth/dashboard/templates/euth_dashboard/organisation_form.html
+++ b/euth/dashboard/templates/euth_dashboard/organisation_form.html
@@ -13,7 +13,7 @@
 
         {% for field in form.untranslated %}
         <div class="form-group{% if field.errors %} has-error{% endif %}">
-            <label>{{ field.label }}</label>
+            <label for="{{field.id_for_label}}">{{ field.label }}</label>
             {% if field.help_text %}
             <p><i>{{ field.help_text }}</i></p>
             {% endif %}
@@ -45,7 +45,7 @@
         <div class="language-switch-panel {% if forloop.first %}active{% endif %}" id="{{ lang_code }}_language_panel">
             {% for field in fields %}
             <div class="form-group{% if field.errors %} has-error{% endif %}">
-                <label>{{ field.label }}</label>
+                <label for="{{field.id_for_label}}">{{ field.label }}</label>
                 {% if field.help_text %}
                 <p><i>{{ field.help_text }}</i></p>
                 {% endif %}

--- a/euth_wagtail/assets/scss/components/_action-bar.scss
+++ b/euth_wagtail/assets/scss/components/_action-bar.scss
@@ -82,7 +82,6 @@
     }
 
     .open {
-        outline: none;
         background-color: transparent;
         box-shadow: none;
 
@@ -107,7 +106,6 @@
         &:hover,
         &:active,
         &:visited {
-            outline: none;
             background-color: transparent;
             box-shadow: none;
         }

--- a/euth_wagtail/assets/scss/components/_comments.scss
+++ b/euth_wagtail/assets/scss/components/_comments.scss
@@ -13,7 +13,6 @@
     }
 
     & textarea:focus {
-        border: 1px solid $gray;
         border-radius: 0;
         @include rem(font-size, 14px);
     }

--- a/euth_wagtail/assets/scss/components/_modal.scss
+++ b/euth_wagtail/assets/scss/components/_modal.scss
@@ -51,11 +51,6 @@
     .close {
         opacity: 1;
 
-        &:focus,
-        &:hover {
-            outline: none;
-        }
-
         & i {
             color: $gray-darker;
         }
@@ -67,11 +62,6 @@
         &:active {
             background-color: transparent;
             box-shadow: none;
-        }
-
-        &:focus,
-        &:hover {
-            outline: none;
         }
     }
 

--- a/euth_wagtail/assets/scss/components/forms/_general-form.scss
+++ b/euth_wagtail/assets/scss/components/forms/_general-form.scss
@@ -10,10 +10,6 @@
         color: $black;
     }
 
-    .form-control {
-        border: 1px solid $gray;
-    }
-
     textarea {
         min-height: 6rem;
         padding: ($padding-large-vertical * 2) 12px;

--- a/euth_wagtail/assets/scss/core/_bootstrap-variables.scss
+++ b/euth_wagtail/assets/scss/core/_bootstrap-variables.scss
@@ -211,7 +211,7 @@ $input-bg-disabled:              $gray-lighter !default;
 //** Text color for `<input>`s
 $input-color:                    $gray !default;
 //** `<input>` border color
-$input-border:                   #ccc !default;
+$input-border:                   $gray !default;
 
 // TODO: Rename `$input-border-radius` to `$input-border-radius-base` in v4
 //** Default `.form-control` border radius

--- a/euth_wagtail/assets/scss/core/_buttons.scss
+++ b/euth_wagtail/assets/scss/core/_buttons.scss
@@ -155,7 +155,6 @@
     &:hover,
     &:active,
     &:visited {
-        outline: none;
         background-color: transparent;
         box-shadow: none;
     }


### PR DESCRIPTION
When playing with the project creation form in the dashboard I noticed two accessibility related issues:

- some labels wer not properly associated with their input elements (missing `for` property)
- the input did not indicate the focus

My fix probably changes some styling somewhere. But I do not yet have the overview to estimate the exact effects.