### PR TITLE
Mn 2016 11 notify moderators on idea added

### DIFF
--- a/euth/actions/emails.py
+++ b/euth/actions/emails.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib import auth
 from django.utils import translation
 
@@ -19,8 +21,10 @@ def notify_creator_on_create_action(action):
         'url': url,
     }
 
+    jsonDec = json.decoder.JSONDecoder()
+
     emails.send_email_with_template(
-        [action.target.creator.email], 'notify_creator', context)
+        jsonDec.decode(action.recipients), 'notify_creator', context)
 
 
 def notify_followers_on_almost_finished(project):

--- a/euth/actions/migrations/0003_action_recipients.py
+++ b/euth/actions/migrations/0003_action_recipients.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('euth_actions', '0002_make_user_optional'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='action',
+            name='recipients',
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/euth/actions/models.py
+++ b/euth/actions/models.py
@@ -43,6 +43,8 @@ class Action(models.Model):
     verb = models.CharField(max_length=255, db_index=True)
     description = models.TextField(blank=True, null=True)
 
+    recipients = models.TextField(blank=True, null=True)
+
     def __str__(self):
 
         ctx = {

--- a/euth/actions/signals.py
+++ b/euth/actions/signals.py
@@ -9,9 +9,7 @@ from .models import Action
 @receiver(post_save, sender=Action)
 def send_notification(sender, instance, created, **kwargs):
 
-    if instance.verb == 'created' and hasattr(instance.target, 'creator'):
-        creator = instance.target.creator
-        if creator.get_notifications and not creator == instance.actor:
-            emails.notify_creator_on_create_action(instance)
+    if instance.verb == 'created':
+        emails.notify_creator_on_create_action(instance)
     if instance.verb == 'project almost finished':
         emails.notify_followers_on_almost_finished(instance.project)


### PR DESCRIPTION
Within this PR I added a field _recipients_ to the action model. A list of email addresses (of the recipients ) is saved as JSON in this field. By this we can move logic (e.g. get recipients and check if the get_notification flag is set  or if the creator of a comment is not the creator of the idea etc.) from the Action to the models and apps, which create the Action instance. 

I am also against moving the creation of Actions from the signals in comments and ideas to Actions to keep the Action App slim and dont add too many dependencies to other apps.

I am just not sure, if we should save a JSON in the Database?
 