### PR TITLE
Hide flashpoll iframe if fp phase has finished

### DIFF
--- a/euth/flashpoll/templates/euth_flashpoll/flashpoll_detail.html
+++ b/euth/flashpoll/templates/euth_flashpoll/flashpoll_detail.html
@@ -1,5 +1,7 @@
 {% extends 'euth_projects/project_detail.html' %}
 {% load i18n %}
 {% block phase_content %}
-    <iframe src="{{ url }}" frameborder="0" style="width: 100%; height: 500px;"></iframe>
+{% if not view.phase.is_over %}
+<iframe src="{{ url }}" frameborder="0" style="width: 100%; height: 500px;"></iframe>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Quick fix #550 

Propper solution would be to disable the controls in flashpoll, while still showing results. That will work if the FP admin is there. Until now I just remove the iframe after phase has finished.