### PR TITLE
Remove clash between adhocracy4 library names

### DIFF
--- a/euth_wagtail/templates/base.html
+++ b/euth_wagtail/templates/base.html
@@ -29,7 +29,7 @@
         {% endblock %}
 
         {% render_bundle 'vendor' 'css' %}
-        {% render_bundle 'opin' 'css' %}
+        {% render_bundle 'adhocracy4' 'css' %}
 
         {# Global javascript #}
         <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
@@ -39,7 +39,7 @@
         </script>
 
         {% render_bundle 'vendor' 'js' %}
-        {% render_bundle 'opin' 'js' %}
+        {% render_bundle 'adhocracy4' 'js' %}
     </head>
 
     <body class="{% block body_class %}{% endblock %}">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ var autoprefixer = require('autoprefixer');
 
 module.exports = {
   entry: {
-    opin: [
+    adhocracy4: [
       './euth_wagtail/assets/scss/all.scss',
       './euth/contrib/static/js/app.js'
     ],
@@ -49,7 +49,7 @@ module.exports = {
   devtool: 'eval',
   output: {
     libraryTarget: 'var',
-    library: 'adhocracy4',
+    library: '[name]',
     path: './euth_wagtail/static/',
     publicPath: "/static/",
     filename: '[name].js'


### PR DESCRIPTION
 - prevents override of global var  if same library name is used from
   different bundles

fixes #687 