### PR TITLE
add a detail view for invites

### DIFF
--- a/euth/memberships/models.py
+++ b/euth/memberships/models.py
@@ -42,7 +42,7 @@ class Invite(base.TimeStampedModel):
 
     def get_absolute_url(self):
         url_kwargs = {'invite_token': self.token}
-        return reverse('membership-invite-accept', kwargs=url_kwargs)
+        return reverse('membership-invite-detail', kwargs=url_kwargs)
 
     def accept(self, user):
         self.project.participants.add(user)

--- a/euth/memberships/templates/emails/invite.en.html
+++ b/euth/memberships/templates/emails/invite.en.html
@@ -7,7 +7,7 @@ Your have been invited to {{ invite.project.name }}
 <p>Dear {{ receiver }},</p>
 
 <p>
-    <a href="{{ invite.project.organisation.get_absolute_url }}">{{ invite.project.organisation }}</a>
+    <a href="{{ email.get_host }}{{ invite.project.organisation.get_absolute_url }}">{{ invite.project.organisation }}</a>
     has invited you to join {{ invite.project.name }}.
 </p>
 

--- a/euth/memberships/templates/euth_memberships/invite_base.html
+++ b/euth/memberships/templates/euth_memberships/invite_base.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% blocktrans with project=invite.project.name %} Private project: {{ project }}{% endblocktrans %}{% endblock %}
+{% block content %}
+{% include 'euth_projects/includes/project_hero_unit.html' with project=invite.project %}
+<nav class="tabs">
+    <div class="container">
+        <ul>
+            <li class="col-md-4 col-md-offset-4 active"><a href="#information" data-toggle="tab" class="tab">{% trans "Information" %}</a></li>
+        </ul>
+    </div>
+</nav>
+<div class="container membership-invite">
+    <h2>{% blocktrans with project=invite.project.name %} Do you want to join {{ project }}?{% endblocktrans %}</h2>
+    {{ form.non_field_errors }}
+    <div class="container-narrow">
+        <p>
+            {% trans "You were invited by the initiator of the project. If you accept you will be able to participate in the project. If you decline the invitation, you can also ask for membership at a later time." %}
+        </p>
+    </div>
+    {% block invite_action %}{% endblock %}
+</div>
+{% endblock %}

--- a/euth/memberships/templates/euth_memberships/invite_detail.html
+++ b/euth/memberships/templates/euth_memberships/invite_detail.html
@@ -1,0 +1,5 @@
+{% extends "euth_memberships/invite_base.html" %}
+{% load i18n %}
+{% block invite_action %}
+<a class="btn btn-primary" href="{% url 'account_login' %}?next={% url 'membership-invite-detail' invite_token=invite.token %}">{% trans "Proceed to login" %}</a>
+{% endblock %}

--- a/euth/memberships/templates/euth_memberships/invite_form.html
+++ b/euth/memberships/templates/euth_memberships/invite_form.html
@@ -1,28 +1,9 @@
-{% extends "base.html" %}
+{% extends "euth_memberships/invite_base.html" %}
 {% load i18n %}
-
-{% block title %}{% blocktrans with project=invite.project.name %} Private project: {{ project }}{% endblocktrans %}{% endblock %}
-{% block content %}
-{% include 'euth_projects/includes/project_hero_unit.html' with project=invite.project %}
-<nav class="tabs">
-    <div class="container">
-        <ul>
-            <li class="col-md-4 col-md-offset-4 active"><a href="#information" data-toggle="tab" class="tab">{% trans "Information" %}</a></li>
-        </ul>
-    </div>
-</nav>
-<div class="container membership-invite">
-    <h2>{% blocktrans with project=invite.project.name %} Do you want to join {{ project }}?{% endblocktrans %}</h2>
-    {{ form.non_field_errors }}
-    <div class="container-narrow">
-        <p>You were invited by the initiator of the project. If you accept you will be able to participate in the project.
-            If you decline the invitation, you can also ask for membership at a later time.</p>
-    </div>
-    <form method='POST'>
-        {% csrf_token %}
-        <button type="submit" name="accept" class="btn btn-primary">{% trans 'Accept' %}</button>
-        <button type="submit" name="reject" class="btn btn-danger">{% trans 'Decline' %}</button>
-    </form>
-</div>
-
+{% block invite_action %}
+<form method="POST">
+    {% csrf_token %}
+    <button type="submit" name="accept" class="btn btn-primary">{% trans 'Accept' %}</button>
+    <button type="submit" name="reject" class="btn btn-danger">{% trans 'Decline' %}</button>
+</form>
 {% endblock %}

--- a/euth/memberships/urls.py
+++ b/euth/memberships/urls.py
@@ -8,9 +8,15 @@ urlpatterns = [
         views.RequestView.as_view(),
         name='memberships-request'
     ),
+
+    url(
+        r'^invites/(?P<invite_token>[-\w_]+)/$',
+        views.InviteDetailView.as_view(),
+        name='membership-invite-detail'
+    ),
     url(
         r'^invites/(?P<invite_token>[-\w_]+)/accept/$',
-        views.InviteView.as_view(),
-        name='membership-invite-accept'
+        views.InviteUpdateView.as_view(),
+        name='membership-invite-update'
     ),
  ]

--- a/euth/memberships/views.py
+++ b/euth/memberships/views.py
@@ -37,7 +37,22 @@ class RequestsProjectDetailView(prj_views.ProjectDetailView):
                             project_slug=self.project.slug)
 
 
-class InviteView(mixin.LoginRequiredMixin, generic.UpdateView):
+class InviteDetailView(generic.DetailView):
+    model = models.Invite
+    slug_field = 'token'
+    slug_url_kwarg = 'invite_token'
+
+    def dispatch(self, request, invite_token, *args, **kwargs):
+        if request.user.is_authenticated():
+            return redirect(
+                'membership-invite-update',
+                invite_token=invite_token
+            )
+        else:
+            return super().dispatch(request, *args, **kwargs)
+
+
+class InviteUpdateView(mixin.LoginRequiredMixin, generic.UpdateView):
     model = models.Invite
     form_class = forms.InviteForm
     slug_field = 'token'

--- a/tests/memberships/test_memberships_models.py
+++ b/tests/memberships/test_memberships_models.py
@@ -43,7 +43,7 @@ def test_invite_email(project, user):
     message = mail.outbox[0]
     assert message.subject == subject.format(name=project.name)
     assert message.to == [email]
-    invite_url = 'https://example.com/en/memberships/invites/{}/accept'
+    invite_url = 'https://example.com/en/memberships/invites/{}'
     assert invite_url.format(invite.token) in message.body
 
 

--- a/tests/memberships/test_memberships_views.py
+++ b/tests/memberships/test_memberships_views.py
@@ -82,8 +82,25 @@ def test_create_request(client, project, user):
 
 
 @pytest.mark.django_db
+def test_view_invite(client, invite, user):
+    url = reverse('membership-invite-detail',
+                  kwargs={'invite_token': invite.token})
+    response = client.get(url)
+    assert response.status_code == 200
+    assert (
+        'euth_projects/includes/project_hero_unit.html'
+        in templates_used(response)
+    )
+    assert 'euth_memberships/invite_detail.html' in templates_used(response)
+
+    client.login(username=user.email, password='password')
+    response = client.get(url)
+    assert redirect_target(response) == 'membership-invite-update'
+
+
+@pytest.mark.django_db
 def test_accept_invite(client, invite, user):
-    url = reverse('membership-invite-accept',
+    url = reverse('membership-invite-update',
                   kwargs={'invite_token': invite.token})
     response = client.get(url)
     assert redirect_target(response) == 'account_login'


### PR DESCRIPTION
 - rename old view to update and still require login
 - new view doesn't require login and explains the invite first

This is related to some email issue, but also intended to be an overall improvment for the invite flow.